### PR TITLE
Fix a bug

### DIFF
--- a/Entea/Twig/Extension/AssetExtension.php
+++ b/Entea/Twig/Extension/AssetExtension.php
@@ -30,9 +30,9 @@ class AssetExtension extends  \Twig_Extension
         $assetDir = isset($this->options['asset.directory']) ? 
             $this->options['asset.directory'] : 
             $this->app['request']->getBasePath();
-		
-		if(strpos($assetDir, '/') !== 0)
-			$assetDir = '/'.$assetDir;
+
+        if(strpos($assetDir, '/') !== 0)
+            $assetDir = '/'.$assetDir;
 		
         return sprintf('%s/%s', $assetDir, ltrim($url, '/'));
     }


### PR DESCRIPTION
Fix a bug which occurs when an `asset.directory` is declared and starts by "./web" or just by the name as example "web/", and if the css is called from an url which doesn't start by the base root as example "http://website.com/page/user".
The asset path was "http://website.com/page/user/web/css/custom.css" and not "http://website.com/web/css/custom.css".
